### PR TITLE
WAMS Xblock changes to capture video download Url in CMS

### DIFF
--- a/azure_media_services/ams.py
+++ b/azure_media_services/ams.py
@@ -101,11 +101,17 @@ class AMSXBlock(StudioEditableXBlockMixin, XBlock):
         help=_("A transcript URL"),
         scope=Scope.settings
     )
+	
+	download_url = String(
+        display_name=_("Video Download URL"),
+        help=_("A download URL"),
+        scope=Scope.settings
+    )
 
     # These are what become visible in the Mixin editor
     editable_fields = (
         'display_name', 'video_url', 'verification_key', 'protection_type',
-        'token_issuer', 'token_scope', 'token_expiry_mins', 'captions', 'transcript_url',
+        'token_issuer', 'token_scope', 'token_expiry_mins', 'captions', 'transcript_url', 'download_url',
     )
 
     def _get_context_for_template(self):
@@ -117,6 +123,7 @@ class AMSXBlock(StudioEditableXBlockMixin, XBlock):
             "protection_type": self.protection_type,
             "captions": self.captions,
             "transcript_url": self.transcript_url,
+			"download_url": self.download_url,
         }
 
         if self.protection_type:

--- a/azure_media_services/ams.py
+++ b/azure_media_services/ams.py
@@ -102,7 +102,7 @@ class AMSXBlock(StudioEditableXBlockMixin, XBlock):
         scope=Scope.settings
     )
 	
-	download_url = String(
+    download_url_url = String(
         display_name=_("Video Download URL"),
         help=_("A download URL"),
         scope=Scope.settings

--- a/azure_media_services/ams.py
+++ b/azure_media_services/ams.py
@@ -123,7 +123,7 @@ class AMSXBlock(StudioEditableXBlockMixin, XBlock):
             "protection_type": self.protection_type,
             "captions": self.captions,
             "transcript_url": self.transcript_url,
-			"download_url": self.download_url,
+            "download_url": self.download_url,			
         }
 
         if self.protection_type:

--- a/azure_media_services/ams.py
+++ b/azure_media_services/ams.py
@@ -101,8 +101,7 @@ class AMSXBlock(StudioEditableXBlockMixin, XBlock):
         help=_("A transcript URL"),
         scope=Scope.settings
     )
-	
-    download_url_url = String(
+    download_url = String(
         display_name=_("Video Download URL"),
         help=_("A download URL"),
         scope=Scope.settings

--- a/azure_media_services/static/js/player.js
+++ b/azure_media_services/static/js/player.js
@@ -117,10 +117,16 @@ function AzureMediaServicesBlock(runtime, element) {
       // I'm wondering if something is handling the event ahead of us and not passing downstream
       subtitle_els.mousedown(function(evt) {
         var target = $(evt.target);
-        var language_name = target.html()
+        var language_name = target.html();
+		var event_type = 'edx.video.closed_captions.shown';
+		if (language_name == 'Off') {
+			event_type = 'edx.video.closed_captions.hidden';
+			language_name = '';
+		}
+			
         _sendPlayerEvent(
           eventPostUrl,
-          'edx.video.closed_captions.shown',
+          event_type,
           {
             language_name: language_name
           }

--- a/azure_media_services/static/js/player.js
+++ b/azure_media_services/static/js/player.js
@@ -99,12 +99,7 @@ function AzureMediaServicesBlock(runtime, element) {
     }
 
 
-    //
-    // Some experimental code here, that we'll disable, but keep around for future reference
-    //
-    if (true) {
-
-      $(".vjs-subtitles-button").after(
+    $(".vjs-subtitles-button").after(
   '<div aria-pressed="false" aria-label="Subtitles Menu" aria-haspopup="true" tabindex="0" aria-live="polite" role="button" class="vjs-subtitles-button vjs-menu-button vjs-control  amp-subtitles-control"><div class="vjs-control-content"><span class="vjs-control-text">Subtitles</span><div style="display: none;" class="vjs-menu"><ul class="vjs-menu-content"><li aria-selected="true" tabindex="0" aria-live="polite" role="button" class="vjs-menu-item vjs-selected">Off</li><li aria-selected="false" tabindex="0" aria-live="polite" role="button" class="vjs-menu-item">english</li><li aria-selected="false" tabindex="0" aria-live="polite" role="button" class="vjs-menu-item">spanish</li><li aria-selected="false" tabindex="0" aria-live="polite" role="button" class="vjs-menu-item">french</li><li aria-selected="false" tabindex="0" aria-live="polite" role="button" class="vjs-menu-item">italian</li><li class="amp-menu-header">Subtitles</li></ul></div></div></div>'
       );
 	  
@@ -113,8 +108,6 @@ function AzureMediaServicesBlock(runtime, element) {
       // this could change over time (i.e. class names changing)
       var subtitle_els = $(element).find('.vjs-subtitles-button .vjs-menu-item');
 
-      // Unfortunately we can't seem to get the 'click' event to register here.
-      // I'm wondering if something is handling the event ahead of us and not passing downstream
       subtitle_els.mousedown(function(evt) {
         var target = $(evt.target);
         var language_name = target.html();
@@ -132,8 +125,6 @@ function AzureMediaServicesBlock(runtime, element) {
           }
         )
       });
-    }
-
   });
 }
 

--- a/azure_media_services/static/js/player.js
+++ b/azure_media_services/static/js/player.js
@@ -102,9 +102,13 @@ function AzureMediaServicesBlock(runtime, element) {
     //
     // Some experimental code here, that we'll disable, but keep around for future reference
     //
-    if (false) {
+    if (true) {
 
-      // Sink events when the user clicks to show a subtitle.
+      $(".vjs-subtitles-button").after(
+  '<div aria-pressed="false" aria-label="Subtitles Menu" aria-haspopup="true" tabindex="0" aria-live="polite" role="button" class="vjs-subtitles-button vjs-menu-button vjs-control  amp-subtitles-control"><div class="vjs-control-content"><span class="vjs-control-text">Subtitles</span><div style="display: none;" class="vjs-menu"><ul class="vjs-menu-content"><li aria-selected="true" tabindex="0" aria-live="polite" role="button" class="vjs-menu-item vjs-selected">Off</li><li aria-selected="false" tabindex="0" aria-live="polite" role="button" class="vjs-menu-item">english</li><li aria-selected="false" tabindex="0" aria-live="polite" role="button" class="vjs-menu-item">spanish</li><li aria-selected="false" tabindex="0" aria-live="polite" role="button" class="vjs-menu-item">french</li><li aria-selected="false" tabindex="0" aria-live="polite" role="button" class="vjs-menu-item">italian</li><li class="amp-menu-header">Subtitles</li></ul></div></div></div>'
+      );
+	  
+	  // Sink events when the user clicks to show a subtitle.
       // NOTE that we are sinking events from the Azure Media Player, so
       // this could change over time (i.e. class names changing)
       var subtitle_els = $(element).find('.vjs-subtitles-button .vjs-menu-item');
@@ -122,10 +126,6 @@ function AzureMediaServicesBlock(runtime, element) {
           }
         )
       });
-
-      $(".vjs-subtitles-button").after(
-  '<div aria-pressed="false" aria-label="Subtitles Menu" aria-haspopup="true" tabindex="0" aria-live="polite" role="button" class="vjs-subtitles-button vjs-menu-button vjs-control  amp-subtitles-control"><div class="vjs-control-content"><span class="vjs-control-text">Subtitles</span><div style="display: none;" class="vjs-menu"><ul class="vjs-menu-content"><li aria-selected="true" tabindex="0" aria-live="polite" role="button" class="vjs-menu-item vjs-selected">Off</li><li aria-selected="false" tabindex="0" aria-live="polite" role="button" class="vjs-menu-item">english</li><li aria-selected="false" tabindex="0" aria-live="polite" role="button" class="vjs-menu-item">spanish</li><li aria-selected="false" tabindex="0" aria-live="polite" role="button" class="vjs-menu-item">french</li><li aria-selected="false" tabindex="0" aria-live="polite" role="button" class="vjs-menu-item">italian</li><li class="amp-menu-header">Subtitles</li></ul></div></div></div>'
-      );
     }
 
   });

--- a/azure_media_services/templates/player.html
+++ b/azure_media_services/templates/player.html
@@ -29,14 +29,14 @@
 % endif
 
 <ul class="wrapper-downloads">
+% if download_url:
 	<li class="video-sources video-download-button">
-	% if download_url:
 		<a href="${download_url}">Download video</a>
-	% endif
 	</li>
+% endif	
+% if transcript_url:
 	<li class="video-tracks video-download-button">
-	% if transcript_url:
 		<a href="${transcript_url}">Download transcript</a>
-	% endif
 	</li>
+% endif	
 </ul>

--- a/azure_media_services/templates/player.html
+++ b/azure_media_services/templates/player.html
@@ -27,4 +27,7 @@
     <div class='azure-media-player-transcript-pane' data-transcript-url="${transcript_url}">
     </div>
 % endif
+% if download_url:
+    <a href="${download_url}" download> download video </a>
+% endif
 </div>

--- a/azure_media_services/templates/player.html
+++ b/azure_media_services/templates/player.html
@@ -31,3 +31,31 @@
     <a href="${download_url}" download> download video </a>
 % endif
 </div>
+
+<ul class="wrapper-downloads">
+% if download_url:
+	<li class="video-sources video-download-button">
+		<a href="${download_url}">Download video</a>
+	</li>
+% endif
+	<li class="video-tracks video-download-button">
+		<a href="/courses/course-v1:Microsoft+AZURE204x+2016_T4/xblock/block-v1:Microsoft+AZURE204x+2016_T4+type@video+block@ef8d7a5ad43741cab8f5bd3083cea41f/handler/transcript/download">Download transcript</a>
+		<div class="a11y-menu-container">
+			<a class="a11y-menu-button" href="#" title=".srt" role="button" aria-disabled="false">.txt</a>
+			<ol class="a11y-menu-list" role="menu">
+			  <li class="a11y-menu-item">
+			  
+				  <a class="a11y-menu-item-link" href="#srt" title="SubRip (.srt) file" data-value="srt" role="menuitem" aria-disabled="false">
+					SubRip (.srt) file
+				  </a>
+			  </li>
+			  <li class="a11y-menu-item active">
+			  
+				  <a class="a11y-menu-item-link" href="#txt" title="Text (.txt) file" data-value="txt" role="menuitem" aria-disabled="false">
+					Text (.txt) file
+				  </a>
+			  </li>
+			</ol>
+		</div>
+	</li>
+  </ul>

--- a/azure_media_services/templates/player.html
+++ b/azure_media_services/templates/player.html
@@ -27,35 +27,16 @@
     <div class='azure-media-player-transcript-pane' data-transcript-url="${transcript_url}">
     </div>
 % endif
-% if download_url:
-    <a href="${download_url}" download> download video </a>
-% endif
-</div>
 
 <ul class="wrapper-downloads">
-% if download_url:
 	<li class="video-sources video-download-button">
+	% if download_url:
 		<a href="${download_url}">Download video</a>
+	% endif
 	</li>
-% endif
 	<li class="video-tracks video-download-button">
-		<a href="/courses/course-v1:Microsoft+AZURE204x+2016_T4/xblock/block-v1:Microsoft+AZURE204x+2016_T4+type@video+block@ef8d7a5ad43741cab8f5bd3083cea41f/handler/transcript/download">Download transcript</a>
-		<div class="a11y-menu-container">
-			<a class="a11y-menu-button" href="#" title=".srt" role="button" aria-disabled="false">.txt</a>
-			<ol class="a11y-menu-list" role="menu">
-			  <li class="a11y-menu-item">
-			  
-				  <a class="a11y-menu-item-link" href="#srt" title="SubRip (.srt) file" data-value="srt" role="menuitem" aria-disabled="false">
-					SubRip (.srt) file
-				  </a>
-			  </li>
-			  <li class="a11y-menu-item active">
-			  
-				  <a class="a11y-menu-item-link" href="#txt" title="Text (.txt) file" data-value="txt" role="menuitem" aria-disabled="false">
-					Text (.txt) file
-				  </a>
-			  </li>
-			</ol>
-		</div>
+	% if transcript_url:
+		<a href="${transcript_url}">Download transcript</a>
+	% endif
 	</li>
-  </ul>
+</ul>


### PR DESCRIPTION
Currently, we do not have property/field to capture the video download url in this xblock.
This change actually add new editable field/property in the xblock to capture the download url, and in the CMS provide two buttons to download the url and transcripts.
FYI: Styles part ashish is working on.