### PR TITLE
Check to verify the AES or DRM based on that update context

### DIFF
--- a/azure_media_services/ams.py
+++ b/azure_media_services/ams.py
@@ -127,28 +127,28 @@ class AMSXBlock(StudioEditableXBlockMixin, XBlock):
 
         if self.protection_type:
             if self.protection_type == 'AES':
-			    # Create a JWT authentication token to have the Azure Media Services
-		        # create necessary DRM licenses
+			# Create a JWT authentication token to have the Azure Media Services
+			# create necessary DRM licenses
 
-		        secret = base64.b64decode(self.verification_key)
+			secret = base64.b64decode(self.verification_key)
 
-			    payload = {
-				    u"iss": unicode(self.token_issuer),
-				    u"aud": unicode(self.token_scope),
-				    u"exp": int(time.time()) + (self.token_expiry_mins * 60),
-			    }
+			payload = {
+				u"iss": unicode(self.token_issuer),
+				u"aud": unicode(self.token_scope),
+				u"exp": int(time.time()) + (self.token_expiry_mins * 60),
+			}
 
-			    auth_token = jwt.encode(
-				    payload,
-				    secret,
-				    algorithm='HS256'
-			    )
-		    else:
-			    auth_token = self.verification_key
+			auth_token = jwt.encode(
+				payload,
+			secret,
+			algorithm='HS256'
+		)
+		else:
+			auth_token = self.verification_key
 				
-            context.update({
-                "auth_token": auth_token,
-            })
+        context.update({
+            "auth_token": auth_token,
+        })
 
         return context
 

--- a/azure_media_services/ams.py
+++ b/azure_media_services/ams.py
@@ -126,25 +126,25 @@ class AMSXBlock(StudioEditableXBlockMixin, XBlock):
         }
 
         if self.protection_type:
-			if self.protection_type == 'AES':
-				# Create a JWT authentication token to have the Azure Media Services
-				# create necessary DRM licenses
+            if self.protection_type == 'AES':
+			    # Create a JWT authentication token to have the Azure Media Services
+		        # create necessary DRM licenses
 
-				secret = base64.b64decode(self.verification_key)
+		        secret = base64.b64decode(self.verification_key)
 
-				payload = {
-					u"iss": unicode(self.token_issuer),
-					u"aud": unicode(self.token_scope),
-					u"exp": int(time.time()) + (self.token_expiry_mins * 60),
-				}
+			    payload = {
+				    u"iss": unicode(self.token_issuer),
+				    u"aud": unicode(self.token_scope),
+				    u"exp": int(time.time()) + (self.token_expiry_mins * 60),
+			    }
 
-				auth_token = jwt.encode(
-					payload,
-					secret,
-					algorithm='HS256'
-				)
-			else:
-				auth_token = self.verification_key
+			    auth_token = jwt.encode(
+				    payload,
+				    secret,
+				    algorithm='HS256'
+			    )
+		    else:
+			    auth_token = self.verification_key
 				
             context.update({
                 "auth_token": auth_token,

--- a/azure_media_services/ams.py
+++ b/azure_media_services/ams.py
@@ -127,28 +127,28 @@ class AMSXBlock(StudioEditableXBlockMixin, XBlock):
 
         if self.protection_type:
             if self.protection_type == 'AES':
-			# Create a JWT authentication token to have the Azure Media Services
-			# create necessary DRM licenses
+		# Create a JWT authentication token to have the Azure Media Services
+		# create necessary DRM licenses
 
-			secret = base64.b64decode(self.verification_key)
+		secret = base64.b64decode(self.verification_key)
 
-			payload = {
-				u"iss": unicode(self.token_issuer),
-				u"aud": unicode(self.token_scope),
-				u"exp": int(time.time()) + (self.token_expiry_mins * 60),
-			}
+		payload = {
+			u"iss": unicode(self.token_issuer),
+		        u"aud": unicode(self.token_scope),
+			u"exp": int(time.time()) + (self.token_expiry_mins * 60),
+		}
 
-			auth_token = jwt.encode(
-				payload,
+		auth_token = jwt.encode(
+			payload,
 			secret,
 			algorithm='HS256'
 		)
 		else:
-			auth_token = self.verification_key
+		    auth_token = self.verification_key
 				
-        context.update({
-            "auth_token": auth_token,
-        })
+		context.update({
+			"auth_token": auth_token,
+		})
 
         return context
 

--- a/azure_media_services/ams.py
+++ b/azure_media_services/ams.py
@@ -127,27 +127,27 @@ class AMSXBlock(StudioEditableXBlockMixin, XBlock):
 
         if self.protection_type:
             if self.protection_type == 'AES':
-		# Create a JWT authentication token to have the Azure Media Services
-		# create necessary DRM licenses
+                # Create a JWT authentication token to have the Azure Media Services
+                # create necessary DRM licenses
 
-		secret = base64.b64decode(self.verification_key)
+                secret = base64.b64decode(self.verification_key)
 
-		payload = {
-			u"iss": unicode(self.token_issuer),
-		        u"aud": unicode(self.token_scope),
-			u"exp": int(time.time()) + (self.token_expiry_mins * 60),
-		}
+                payload = {
+                    u"iss": unicode(self.token_issuer),
+                    u"aud": unicode(self.token_scope),
+                    u"exp": int(time.time()) + (self.token_expiry_mins * 60),
+                }
 
-		auth_token = jwt.encode(
-			payload,
-			secret,
-			algorithm='HS256'
-		)
-	    else:
-	        auth_token = self.verification_key
+                auth_token = jwt.encode(
+                    payload,
+                    secret,
+                    algorithm='HS256'
+                )
+            else:
+                auth_token = self.verification_key
 				
 	    context.update({
-		"auth_token": auth_token,
+		    "auth_token": auth_token,
 	    })
 
         return context

--- a/azure_media_services/ams.py
+++ b/azure_media_services/ams.py
@@ -126,23 +126,26 @@ class AMSXBlock(StudioEditableXBlockMixin, XBlock):
         }
 
         if self.protection_type:
-            # Create a JWT authentication token to have the Azure Media Services
-            # create necessary DRM licenses
+			if self.protection_type == 'AES':
+				# Create a JWT authentication token to have the Azure Media Services
+				# create necessary DRM licenses
 
-            secret = base64.b64decode(self.verification_key)
+				secret = base64.b64decode(self.verification_key)
 
-            payload = {
-                u"iss": unicode(self.token_issuer),
-                u"aud": unicode(self.token_scope),
-                u"exp": int(time.time()) + (self.token_expiry_mins * 60),
-            }
+				payload = {
+					u"iss": unicode(self.token_issuer),
+					u"aud": unicode(self.token_scope),
+					u"exp": int(time.time()) + (self.token_expiry_mins * 60),
+				}
 
-            auth_token = jwt.encode(
-                payload,
-                secret,
-                algorithm='HS256'
-            )
-
+				auth_token = jwt.encode(
+					payload,
+					secret,
+					algorithm='HS256'
+				)
+			else:
+				auth_token = self.verification_key
+				
             context.update({
                 "auth_token": auth_token,
             })

--- a/azure_media_services/ams.py
+++ b/azure_media_services/ams.py
@@ -143,12 +143,12 @@ class AMSXBlock(StudioEditableXBlockMixin, XBlock):
 			secret,
 			algorithm='HS256'
 		)
-		else:
-		    auth_token = self.verification_key
+	    else:
+	        auth_token = self.verification_key
 				
-		context.update({
-			"auth_token": auth_token,
-		})
+	    context.update({
+		"auth_token": auth_token,
+	    })
 
         return context
 


### PR DESCRIPTION
Check to verify the AES or DRM based on that update context

For DRM, we are directly getting auth_token so we no need to encode it again with payload., also playload is part of encryption key